### PR TITLE
Fixes issue when a holiday happens on a week-end

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -44,7 +44,7 @@ def official_tgif(holidays):
     today = datetime.date.today()
     weekend_now = [(x-today.weekday()) for x in weekend]
     holidays_now = [(x-today).days for x in holidays]
-    merged_holidays = sorted(holidays_now+weekend_now)
+    merged_holidays = sorted(set(holidays_now+weekend_now))
     merged_holidays = list(filter(lambda x: x >= 0, merged_holidays))
 
     count = max(0, merged_holidays[0]-1)


### PR DESCRIPTION
Example: 31/05/2020 was on a Sunday but it changed the parsing to omit the Monday 01/06/2020, which is also a holiday

Removed doubles in merged_holidays